### PR TITLE
CLOUD-3435: Omit client secret and make client id optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ jobs:
         uses: actions/martini-upload-package-action@main
         with:
           base_url: "http://localhost:8080"
+          client_id: "myclientid"
+          client_secret: "myclientsecret"
           user_name: "myuser"
           user_password: "mycomplexpassword"
           package_dir: "packages/sample-package"
@@ -30,12 +32,16 @@ jobs:
 
 ## Inputs
 
-| Input           | Default | Description                                                                          |
-|-----------------|---------|--------------------------------------------------------------------------------------|
-| `base_url`      | N/A     | Base URL of the Martini instance                                                     |
-| `user_name`     | N/A     | Name of a user on the Martini instance that should be used for uploading the package |
-| `user_password` | N/A     | The user's password                                                                  |
-| `package_dir`   | N/A     | Path to a directory that contains the package's files                                |
+## Inputs
+
+| Input           | Default      | Required | Description                                                                          |
+|-----------------|--------------|----------|--------------------------------------------------------------------------------------|
+| `base_url`      | N/A          | Yes      | Base URL of the Martini instance                                                     |
+| `client_id`     | `TOROMartini`| No       | Client ID of the Martini instance. If omitted, defaults to `TOROMartini`             |
+| `client_secret` | N/A          | No       | Client Secret of the Martini instance                                                 |
+| `user_name`     | N/A          | Yes      | Name of a user on the Martini instance that should be used for uploading the package |
+| `user_password` | N/A          | Yes      | The user's password                                                                  |
+| `package_dir`   | N/A          | Yes      | Path to a directory that contains the package's files                                |
 
 ## Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -8,9 +8,11 @@ inputs:
   client_id:
     description: 'Client ID of the Martini instance'
     required: false
+    default: ''
   client_secret:
     description: 'Client Secret of the Martini instance'
     required: false
+    default: ''
   user_name:
     description: 'Name of a user on the Martini instance that should be used for uploading the package'
     required: true

--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,12 @@ inputs:
   base_url:
     description: 'Base URL of the Martini instance'
     required: true
+  client_id:
+    description: 'Client ID of the Martini instance'
+    required: false
+  client_secret:
+    description: 'Client Secret of the Martini instance'
+    required: false
   user_name:
     description: 'Name of a user on the Martini instance that should be used for uploading the package'
     required: true

--- a/dist/index.js
+++ b/dist/index.js
@@ -64136,6 +64136,12 @@ const MARTINI_BASE_URL = core.getInput('base_url', {
     required: true,
 });
 
+const MARTINI_CLIENT_ID = core.getInput('client_id') || 'TOROMartini';
+
+const MARTINI_CLIENT_SECRET = core.getInput('client_secret', {
+    required: false,
+});
+
 const MARTINI_USER_NAME = core.getInput('user_name', {
     required: true,
 });
@@ -64153,8 +64159,8 @@ const ZIP_PATH = __dirname + `/${PACKAGE_NAME}.zip`;
 
 async function uploadPackage() {
     const tokenParams = new URLSearchParams();
-    tokenParams.append('client_id', 'TOROMartini');
-    tokenParams.append('client_secret', 'TOROMartini');
+    tokenParams.append('client_id', MARTINI_CLIENT_ID);
+    tokenParams.append('client_secret', MARTINI_CLIENT_SECRET);
     tokenParams.append('grant_type', 'password');
     tokenParams.append('password', MARTINI_USER_PASSWORD);
     tokenParams.append('username', MARTINI_USER_NAME);

--- a/index.js
+++ b/index.js
@@ -8,6 +8,12 @@ const MARTINI_BASE_URL = core.getInput('base_url', {
     required: true,
 });
 
+const MARTINI_CLIENT_ID = core.getInput('client_id') || 'TOROMartini';
+
+const MARTINI_CLIENT_SECRET = core.getInput('client_secret', {
+    required: false,
+});
+
 const MARTINI_USER_NAME = core.getInput('user_name', {
     required: true,
 });
@@ -25,8 +31,8 @@ const ZIP_PATH = __dirname + `/${PACKAGE_NAME}.zip`;
 
 async function uploadPackage() {
     const tokenParams = new URLSearchParams();
-    tokenParams.append('client_id', 'TOROMartini');
-    tokenParams.append('client_secret', 'TOROMartini');
+    tokenParams.append('client_id', MARTINI_CLIENT_ID);
+    tokenParams.append('client_secret', MARTINI_CLIENT_SECRET);
     tokenParams.append('grant_type', 'password');
     tokenParams.append('password', MARTINI_USER_PASSWORD);
     tokenParams.append('username', MARTINI_USER_NAME);


### PR DESCRIPTION
https://jira.internal.torocloud.com/browse/CLOUD-3435

- Made Client ID an optional variable. Set to TOROMartini by default if no input found.
- Made Client Secret a optional variable.
- Added inputs on Readme example and table.
- Added required column on Readme table.